### PR TITLE
Add URL to plugin.info.txt

### DIFF
--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -4,4 +4,4 @@ email  none
 date   2016-09-17
 name   disable actions by group plugin
 desc   Prevent specific actions by user group
-url    http://
+url    https://www.dokuwiki.org/plugin:disableactionsbygroup


### PR DESCRIPTION
Documentation link in Extension Manager points to http://. This fixes it.