### PR TITLE
Added support for ALL users (non logged in users)

### DIFF
--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -4,4 +4,4 @@ email  none
 date   2016-09-17
 name   disable actions by group plugin
 desc   Prevent specific actions by user group
-url    http://
+url    https://www.dokuwiki.org/plugin:disableactionsbygroup


### PR DESCRIPTION
Hi,
I've recently been setting up a blog using dokuwiki
and I needed to disable certain features for users that were not logged in
so I've added some code to the plugin so that you can do something like this

```
admin:;ALL:revisions,register,source
```

This leaves admin empty (so everything is enabled), but for ALL which specifies a user not logged in disables the register, old revisions and display source buttons / links
